### PR TITLE
pkg/source: don't clone, just open existing

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -53,7 +53,6 @@ func main() {
 	case "git":
 		repo := source.New(appLogger)
 		repo.Path = "void-packages"
-		repo.Url = "https://github.com/void-linux/void-packages"
 		repo.Bootstrap()
 		repo.Fetch()
 		// Some random commit

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -24,17 +24,12 @@ func (r *RepoMngr) Bootstrap() error {
 	if r.Path == "" {
 		r.l.Warn("Error in repo manager, path must be set to bootstrap")
 	}
-	if r.Url == "" {
-		r.l.Warn("Error in repo manager, url must be set to bootstrap")
-	}
 	r.Mu.Lock()
 	defer r.Mu.Unlock()
-	r.l.Debug("Cloning repository", "path", r.Path, "url", r.Url)
-	// Don't do a shallow clone (Depth: BIG)
-	r.repo, err = git.PlainClone(r.Path, false,
-		&git.CloneOptions{URL: r.Url, Depth: 99999999})
+	r.l.Debug("Opening repository", "path", r.Path)
+	r.repo, err = git.PlainOpen(r.Path)
 	if err != nil {
-		r.l.Trace("Error running PlainClone")
+		r.l.Trace("Error opening repository", "path", r.Path)
 		return err
 	}
 	return nil

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -18,6 +18,11 @@ func New(l hclog.Logger) *RepoMngr {
 	return &x
 }
 
+// SetBasepath sets up the path for the repo to be written to.
+func (r *RepoMngr) SetBasepath(p string) {
+	r.Path = p
+}
+
 // Create a git repository at Path from URL
 func (r *RepoMngr) Bootstrap() error {
 	var err error

--- a/pkg/source/types.go
+++ b/pkg/source/types.go
@@ -11,7 +11,6 @@ import (
 type RepoMngr struct {
 	l    hclog.Logger
 	Path string
-	Url  string
 	Mu   *sync.Mutex
 	repo *git.Repository
 }


### PR DESCRIPTION
In the end it is almost certain that we will get -packages git source
from disk anyway and just manipulate it in ramdisk within nbuild because
cloning is computationally expensive.

Hence the clone should be externalized as we are not interested in a
usecase where the clone is done within nbuild.

Along with this drop the Url field because we are not using that
anymore.