### PR TITLE
docker improvements

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,94 @@
+---
+name: 'Build nbuild containers'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        libc:
+          - glibc
+          - musl
+
+    steps:
+      - name: Checkout
+        uses: classabbyamp/treeless-checkout-action@v1
+
+      - name: Get image release
+        id: release
+        run: |
+          # gets the list of all date-shaped tags for the image, finds the most recent one
+          tag="$(skopeo list-tags "docker://ghcr.io/${{ github.repository_owner }}/nbuild-${{ matrix.libc }}" | \
+            jq -r '.Tags | sort | reverse | map(select(test("^[0-9]{8}(R[0-9]+)?$")))[0]')"
+          # tags from a different day or pre-YYYYMMDDRN
+          if [ "${tag%R*}" != "$(date -u +%Y%m%d)" ] || [ "${tag%R*}" = "${tag}" ]; then
+            rel=1
+          else
+            rel=$(( ${tag##*R} + 1 ))
+          fi
+          echo "rel=${rel}" >> "${GITHUB_OUTPUT}"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/nbuild-${{ matrix.libc }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDD'}}R${{ steps.release.outputs.rel }},enable={{is_default_branch}},priority=1000
+          flavor: latest=false
+          # labels: |
+          #   org.opencontainers.image.authors=Void Linux team and contributors
+          #   org.opencontainers.image.url=https://voidlinux.org
+          #   org.opencontainers.image.documentation=https://github.com/${{ github.repository }}
+          #   org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          #   org.opencontainers.image.vendor=Void Linux
+          #   org.opencontainers.image.title=Void Linux build root
+          #   org.opencontainers.image.description=Image for building packages with nbuild on Void Linux
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GCHR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        id: build_and_push
+        uses: docker/bake-action@v3
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          targets: nbuild-${{ matrix.libc }}
+          files: |
+            docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          set: |
+            _common.cache-to=type=gha
+            _common.cache-from=type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:1.16 as build
+ARG LIBC=glibc
+FROM golang:1.21 as build
 
 WORKDIR /nbuild
 COPY . .
 RUN go mod vendor && go build ./cmd/nbuild/main.go
 
-FROM ghcr.io/void-linux/xbps-src-masterdir:v20211105RC01-x86_64
+FROM ghcr.io/void-linux/void-buildroot-${LIBC}:20231006R1 AS image
 WORKDIR /opt/voidlinux/nbuild
 COPY --from=build /nbuild/main ./nbuild
 COPY docker-entrypoint.sh .

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,20 @@
+target "docker-metadata-action" {}
+
+target "_common" {
+  inherits = ["docker-metadata-action"]
+  cache-to = ["type=local,dest=/tmp/buildx-cache"]
+  cache-from = ["type=local,src=/tmp/buildx-cache"]
+  target = "image"
+}
+
+target "nbuild-glibc" {
+  inherits = ["_common"]
+  platforms = ["linux/amd64", "linux/386", "linux/arm64", "linux/arm/v7", "linux/arm/v6"]
+  args = { "LIBC" = "glibc" }
+}
+
+target "nbuild-musl" {
+  inherits = ["_common"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/arm/v6"]
+  args = { "LIBC" = "musl" }
+}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,9 +4,7 @@ set -e
 
 chroot-git clone /void-packages-origin /hostrepo
 ln -s /hostrepo /opt/voidlinux/nbuild/void-packages
-cd /hostrepo
-chroot-git remote set-url origin https://github.com/void-linux/void-packages.git
-cd -
+chroot-git -C /hostrepo remote set-url origin https://github.com/void-linux/void-packages.git
 
 cat <<! >/hostrepo/etc/conf
 XBPS_CHROOT_CMD=ethereal


### PR DESCRIPTION
- Dockerfile: update source images
    - go 1.21 is current now
    - xbps-src-masterdir has been replaced by void-buildroot-LIBC
- docker-entrypoint.sh: use git -C instead of cd/cd -
- docker-bake.hcl: add bakefile
    - for multiplatform/CI-built images
- .github/workflows/docker.yaml: CI for datestamped container images
    - similar to how it's done for the various void containers
